### PR TITLE
remove deadlock in libsegwayrmp.git

### DIFF
--- a/include/segwayrmp.h.in
+++ b/include/segwayrmp.h.in
@@ -78,7 +78,11 @@ private:
   std::queue<Data> the_queue;
   mutable boost::mutex the_mutex;
   boost::condition_variable the_condition_variable;
+  bool is_alive;
 public:
+
+  ConcurrentQueue() : is_alive(true) {}
+
   void push(Data const& data) {
     boost::mutex::scoped_lock lock(the_mutex);
     the_queue.push(data);
@@ -104,7 +108,7 @@ public:
 
   void wait_and_pop(Data& popped_value) {
     boost::mutex::scoped_lock lock(the_mutex);
-    while(the_queue.empty()) {
+    while(the_queue.empty() && is_alive) {
         the_condition_variable.wait(lock);
     }
     
@@ -117,7 +121,9 @@ public:
   }
   
   void cancel() {
+    boost::mutex::scoped_lock lock(the_mutex);
     the_condition_variable.notify_one();
+    is_alive = false;
   }
 };
 


### PR DESCRIPTION
This patch allows the segway_rmp driver to exit gracefully by removing a potential deadlock situation while cancelling the ConcurrentQueue.
