### PR TITLE
Export -ldl on Linux

### DIFF
--- a/cmake/libsegwayrmp.pc.in
+++ b/cmake/libsegwayrmp.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: @CMAKE_PROJECT_NAME@
 Description: A cross-platform, open source interface to Segway's Robotic Mobile Platforms. It provides access to the interface of the RMP50, 100, 200, and 400 series via either serial rs-232 (VCP) or ftdi usb mode (D2XX).
 Version: @segwayrmp_VERSION@
-Libs: -L${libdir} -lsegwayrmp -lftd2xx
+Libs: -L${libdir} -lsegwayrmp -lftd2xx @segwayrmp_ADDITIONAL_LIBRARIES@
 Cflags: -I${includedir}

--- a/cmake/libsegwayrmpConfig.cmake.in
+++ b/cmake/libsegwayrmpConfig.cmake.in
@@ -25,6 +25,10 @@ if(UNIX)
     /usr/local/lib64
   )
   list(APPEND libsegwayrmp_LIBRARIES ${ftd2xx_LIBRARY})
+  # On linux the symbols for dlopen need to be explicitly linked against
+  if(NOT APPLE)
+    list(APPEND libsegwayrmp_LIBRARIES dl)
+  endif()
 endif()
 
 if(NOT libsegwayrmp_INCLUDE_DIRS OR NOT libsegwayrmp_LIBRARIES)

--- a/cmake/segwayrmp_targets.cmake
+++ b/cmake/segwayrmp_targets.cmake
@@ -33,6 +33,7 @@ if(UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     FILES lib/libftd2xx.a
     DESTINATION lib/
   )
+  set(segwayrmp_ADDITIONAL_LIBRARIES "-ldl")
 endif(UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # Enable pkg-configuration file generation for linux


### PR DESCRIPTION
Fix a bug where the explicit link against -ldl
is not exported by the find_package and
pkg-config files, which causes down stream
projects to fail to compile.

See: http://jenkins.willowgarage.com:8080/job/ros-hydro-segway-rmp_binarydeb_raring_i386/16/console
